### PR TITLE
Fix build issue

### DIFF
--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -18,8 +18,7 @@ export class Utils {
 
   static camelToTitleCase(text: string): string {
     return (
-      text[0].toUpperCase() +
-      text.substr(1).replaceAll(/([a-z])([A-Z])/g, `$1 $2`)
+      text[0].toUpperCase() + text.substr(1).replace(/([a-z])([A-Z])/g, `$1 $2`)
     );
   }
 


### PR DESCRIPTION
build failed bacause Utils.camelToTitleCase() used string.prototype.replaceAll() which will be added
in ES2021.

fix #18